### PR TITLE
[PATCH] USE_PF_INET6 by default for v2.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,12 +152,6 @@ AC_ARG_ENABLE(multihome,
    [MULTIHOME="yes"]
 )
 
-AC_ARG_ENABLE(ipv6,
-   [  --disable-ipv6          Disable UDP/IPv6 support],
-   [PF_INET6="$enableval"],
-   [PF_INET6="yes"]
-)
-
 AC_ARG_ENABLE(port-share,
    [  --disable-port-share    Disable TCP server port-share support (--port-share)],
    [PORT_SHARE="$enableval"],
@@ -579,14 +573,12 @@ AC_CHECK_FUNC(epoll_create, AC_DEFINE(HAVE_EPOLL_CREATE, 1, [epoll_create functi
 LDFLAGS="$OLDLDFLAGS"
 
 dnl ipv6 support
-if test "$PF_INET6" = "yes"; then
-  AC_CHECKING([for struct sockaddr_in6 for IPv6 support])
-  AC_CHECK_TYPE(
+AC_CHECKING([for struct sockaddr_in6 for IPv6 support])
+AC_CHECK_TYPE(
       [struct sockaddr_in6],
-      [AC_DEFINE(USE_PF_INET6, 1, [struct sockaddr_in6 is needed for IPv6 peer support])],
       [],
+      [AC_MSG_ERROR([struct sockaddr_in6 not found, needed for ipv6 transport support.])],
       [#include "syshead.h"])
-fi
 
 dnl
 dnl check for valgrind tool

--- a/init.c
+++ b/init.c
@@ -1745,22 +1745,16 @@ socket_restart_pause (struct context *c)
   switch (c->options.ce.proto)
     {
     case PROTO_UDPv4:
-#ifdef USE_PF_INET6
     case PROTO_UDPv6:
-#endif
       if (proxy)
 	sec = c->options.ce.connect_retry_seconds;
       break;
     case PROTO_TCPv4_SERVER:
-#ifdef USE_PF_INET6
     case PROTO_TCPv6_SERVER:
-#endif
       sec = 1;
       break;
     case PROTO_TCPv4_CLIENT:
-#ifdef USE_PF_INET6
     case PROTO_TCPv6_CLIENT:
-#endif
       sec = c->options.ce.connect_retry_seconds;
       break;
     }
@@ -3188,10 +3182,7 @@ init_instance (struct context *c, const struct env_set *env, const unsigned int 
      instances to inherit acceptable fds
      from a top-level parent */
   if (c->options.ce.proto == PROTO_TCPv4_SERVER
-#ifdef USE_PF_INET6
-      || c->options.ce.proto == PROTO_TCPv6_SERVER
-#endif
-     )
+      || c->options.ce.proto == PROTO_TCPv6_SERVER)
     {
       if (c->mode == CM_TOP)
 	link_socket_mode = LS_MODE_TCP_LISTEN;

--- a/mroute.c
+++ b/mroute.c
@@ -287,7 +287,6 @@ bool mroute_extract_openvpn_sockaddr (struct mroute_addr *addr,
 	}
       return true;
     }
-#ifdef USE_PF_INET6
     case AF_INET6:
       if (use_port)
 	{
@@ -305,7 +304,6 @@ bool mroute_extract_openvpn_sockaddr (struct mroute_addr *addr,
 	  memcpy (addr->addr, &osaddr->addr.in6.sin6_addr, 16);
 	}
       return true;
-#endif
   }
   return false;
 }

--- a/mtcp.c
+++ b/mtcp.c
@@ -151,9 +151,7 @@ multi_tcp_instance_specific_init (struct multi_context *m, struct multi_instance
   ASSERT (mi->context.c2.link_socket->info.lsa);
   ASSERT (mi->context.c2.link_socket->mode == LS_MODE_TCP_ACCEPT_FROM);
   ASSERT (mi->context.c2.link_socket->info.lsa->actual.dest.addr.sa.sa_family == AF_INET
-#ifdef USE_PF_INET6
 	  || mi->context.c2.link_socket->info.lsa->actual.dest.addr.sa.sa_family == AF_INET6
-#endif
 	  );
   if (!mroute_extract_openvpn_sockaddr (&mi->real, &mi->context.c2.link_socket->info.lsa->actual.dest, true))
     {

--- a/multi.c
+++ b/multi.c
@@ -2788,24 +2788,10 @@ tunnel_server (struct context *top)
 {
   ASSERT (top->options.mode == MODE_SERVER);
 
-#ifdef USE_PF_INET6
   if (proto_is_dgram(top->options.ce.proto))
     tunnel_server_udp(top);
   else
     tunnel_server_tcp(top);
-#else
-  switch (top->options.ce.proto)
-    {
-    case PROTO_UDPv4:
-      tunnel_server_udp (top);
-      break;
-    case PROTO_TCPv4_SERVER:
-      tunnel_server_tcp (top);
-      break;
-    default:
-      ASSERT (0);
-    }
-#endif
 }
 
 #else

--- a/options.c
+++ b/options.c
@@ -83,9 +83,7 @@ const char title_string[] =
 #if ENABLE_IP_PKTINFO
   " [MH]"
 #endif
-#ifdef USE_PF_INET6
   " [PF_INET6]"
-#endif
   " [IPv6 payload 20110522-1 (2.2.0)]"
   " built on " __DATE__
 ;
@@ -109,9 +107,7 @@ static const char usage_message[] =
   "--proto p       : Use protocol p for communicating with peer.\n"
   "                  p = udp (default), tcp-server, or tcp-client\n"
   "--proto-force p : only consider protocol p in list of connection profiles.\n"
-#ifdef USE_PF_INET6
   "                  p = udp6, tcp6-server, or tcp6-client (ipv6)\n"
-#endif
   "--connect-retry n : For --proto tcp-client, number of seconds to wait\n"
   "                    between connection retries (default=%d).\n"
   "--connect-timeout n : For --proto tcp-client, connection timeout (in seconds).\n"
@@ -1900,26 +1896,14 @@ options_postprocess_verify_ce (const struct options *options, const struct conne
    */
 
   if (ce->connect_retry_defined && ce->proto != PROTO_TCPv4_CLIENT
-#ifdef USE_PF_INET6
-      && ce->proto != PROTO_TCPv6_CLIENT
-#endif
-      )
-    msg (M_USAGE, "--connect-retry doesn't make sense unless also used with --proto tcp-client"
-#ifdef USE_PF_INET6
-	 " or tcp6-client"
-#endif
-	 );
+      && ce->proto != PROTO_TCPv6_CLIENT)
+    msg (M_USAGE, "--connect-retry doesn't make sense unless also used with "
+	 "--proto tcp-client or tcp6-client");
 
   if (ce->connect_timeout_defined && ce->proto != PROTO_TCPv4_CLIENT
-#ifdef USE_PF_INET6
-      && ce->proto != PROTO_TCPv6_CLIENT
-#endif
-      )
-    msg (M_USAGE, "--connect-timeout doesn't make sense unless also used with --proto tcp-client"
-#ifdef USE_PF_INET6
-	 " or tcp6-client"
-#endif
-	 );
+      && ce->proto != PROTO_TCPv6_CLIENT)
+    msg (M_USAGE, "--connect-timeout doesn't make sense unless also used with "
+	 "--proto tcp-client or tcp6-client");
 
   /*
    * Sanity check on MTU parameters
@@ -2017,10 +2001,7 @@ options_postprocess_verify_ce (const struct options *options, const struct conne
 #endif
 
   if (!ce->remote && (ce->proto == PROTO_TCPv4_CLIENT 
-#ifdef USE_PF_INET6
-		      || ce->proto == PROTO_TCPv6_CLIENT
-#endif
-		      ))
+		      || ce->proto == PROTO_TCPv6_CLIENT))
     msg (M_USAGE, "--remote MUST be used in TCP Client mode");
 
 #ifdef ENABLE_HTTP_PROXY
@@ -2038,12 +2019,8 @@ options_postprocess_verify_ce (const struct options *options, const struct conne
     msg (M_USAGE, "--socks-proxy can not be used in TCP Server mode");
 #endif
 
-  if ((ce->proto == PROTO_TCPv4_SERVER
-#ifdef USE_PF_INET6
-       || ce->proto == PROTO_TCPv6_SERVER
-#endif
-       )
-       && connection_list_defined (options))
+  if ((ce->proto == PROTO_TCPv4_SERVER || ce->proto == PROTO_TCPv6_SERVER)
+      && connection_list_defined (options))
     msg (M_USAGE, "TCP server mode allows at most one --remote address");
 
 #if P2MP_SERVER
@@ -2058,27 +2035,14 @@ options_postprocess_verify_ce (const struct options *options, const struct conne
       if (options->pull)
 	msg (M_USAGE, "--pull cannot be used with --mode server");
       if (!(proto_is_udp(ce->proto) || ce->proto == PROTO_TCPv4_SERVER
-#ifdef USE_PF_INET6
-	    || ce->proto == PROTO_TCPv6_SERVER
-#endif
-	    ))
-	msg (M_USAGE, "--mode server currently only supports --proto udp or --proto tcp-server"
-#ifdef USE_PF_INET6
-	    " or proto tcp6-server"
-#endif
-	     );
+	    || ce->proto == PROTO_TCPv6_SERVER))
+	msg (M_USAGE, "--mode server currently only supports "
+	     "--proto udp or --proto tcp-server or proto tcp6-server");
 #if PORT_SHARE
       if ((options->port_share_host || options->port_share_port) && 
-            (ce->proto != PROTO_TCPv4_SERVER
-#ifdef USE_PF_INET6
-	     && ce->proto != PROTO_TCPv6_SERVER
-#endif
-	     ))
-	msg (M_USAGE, "--port-share only works in TCP server mode (--proto tcp-server"
-#ifdef USE_PF_INET6
-	     " or tcp6-server"
-#endif
-	  ")");
+	  (ce->proto != PROTO_TCPv4_SERVER && ce->proto != PROTO_TCPv6_SERVER))
+	msg (M_USAGE, "--port-share only works in TCP server mode "
+	     "(--proto tcp-server or tcp6-server)");
 #endif
       if (!options->tls_server)
 	msg (M_USAGE, "--mode server requires --tls-server");
@@ -2109,15 +2073,9 @@ options_postprocess_verify_ce (const struct options *options, const struct conne
       if (options->ipchange)
 	msg (M_USAGE, "--ipchange cannot be used with --mode server (use --client-connect instead)");
       if (!(proto_is_dgram(ce->proto) || ce->proto == PROTO_TCPv4_SERVER
-#ifdef USE_PF_INET6
-	    || ce->proto == PROTO_TCPv6_SERVER
-#endif
-	    ))
-	msg (M_USAGE, "--mode server currently only supports --proto udp or --proto tcp-server"
-#ifdef USE_PF_INET6
-	    " or --proto tcp6-server"
-#endif
-	     );
+	    || ce->proto == PROTO_TCPv6_SERVER))
+	msg (M_USAGE, "--mode server currently only supports "
+	     "--proto udp or --proto tcp-server or --proto tcp6-server");
       if (!proto_is_udp(ce->proto) && (options->cf_max || options->cf_per))
 	msg (M_USAGE, "--connect-freq only works with --mode server --proto udp.  Try --max-clients instead.");
       if (!(dev == DEV_TYPE_TAP || (dev == DEV_TYPE_TUN && options->topology == TOP_SUBNET)) && options->ifconfig_pool_netmask)
@@ -2389,10 +2347,8 @@ options_postprocess_mutate_ce (struct options *o, struct connection_entry *ce)
     {
       if (ce->proto == PROTO_TCPv4)
 	ce->proto = PROTO_TCPv4_CLIENT;
-#ifdef USE_PF_INET6
       else if (ce->proto == PROTO_TCPv6)
 	ce->proto = PROTO_TCPv6_CLIENT;
-#endif
     }
 #endif
 

--- a/route.c
+++ b/route.c
@@ -754,11 +754,9 @@ redirect_default_route_to_vpn (struct route_list *rl, const struct tuntap *tt, u
 	  if (!local)
 	    {
 	      /* route remote host to original default gateway */
-#ifdef USE_PF_INET6
 	      /* if remote_host is not ipv4 (ie: ipv6), just skip
 	       * adding this special /32 route */
 	      if (rl->spec.remote_host != IPV4_INVALID_ADDR) {
-#endif
 		add_route3 (rl->spec.remote_host,
 			    ~0,
 			    rl->spec.net_gateway,
@@ -766,11 +764,9 @@ redirect_default_route_to_vpn (struct route_list *rl, const struct tuntap *tt, u
 			    flags,
 			    es);
 		rl->did_local = true;
-#ifdef USE_PF_INET6
 	      } else {
 		dmsg (D_ROUTE, "ROUTE remote_host protocol differs from tunneled");
 	      }
-#endif
 	    }
 
 	  /* route DHCP/DNS server traffic through original default gateway */

--- a/socket.h
+++ b/socket.h
@@ -73,9 +73,7 @@ struct openvpn_sockaddr
   union {
     struct sockaddr sa;
     struct sockaddr_in in4;
-#ifdef USE_PF_INET6
     struct sockaddr_in6 in6;
-#endif
   } addr;
 };
 
@@ -92,9 +90,7 @@ struct link_socket_actual
 #ifdef IP_RECVDSTADDR
     struct in_addr in4;
 #endif
-#ifdef USE_PF_INET6
     struct in6_pktinfo in6;
-#endif
   } pi;
 #endif
 };
@@ -390,12 +386,10 @@ void setenv_link_socket_actual (struct env_set *es,
 
 void bad_address_length (int actual, int expected);
 
-#ifdef USE_PF_INET6
 /* IPV4_INVALID_ADDR: returned by link_socket_current_remote()
  * to ease redirect-gateway logic for ipv4 tunnels on ipv6 endpoints
  */
 #define IPV4_INVALID_ADDR 0xffffffff
-#endif
 in_addr_t link_socket_current_remote (const struct link_socket_info *info);
 
 void link_socket_connection_initiated (const struct buffer *buf,
@@ -521,12 +515,10 @@ enum proto_num {
 	PROTO_TCPv4_SERVER,
 	PROTO_TCPv4_CLIENT,
 	PROTO_TCPv4,
-#ifdef USE_PF_INET6
 	PROTO_UDPv6,
 	PROTO_TCPv6_SERVER,
 	PROTO_TCPv6_CLIENT,
 	PROTO_TCPv6,
-#endif
 	PROTO_N
 };
 
@@ -590,9 +582,7 @@ addr_defined (const struct openvpn_sockaddr *addr)
   if (!addr) return 0;
   switch (addr->addr.sa.sa_family) {
     case AF_INET: return addr->addr.in4.sin_addr.s_addr != 0;
-#ifdef USE_PF_INET6
     case AF_INET6: return !IN6_IS_ADDR_UNSPECIFIED(&addr->addr.in6.sin6_addr);
-#endif
     default: return 0;
   }
 }
@@ -608,9 +598,7 @@ addr_defined_ipi (const struct link_socket_actual *lsa)
 #ifdef IP_RECVDSTADDR
     case AF_INET: return lsa->pi.in4.s_addr != 0;
 #endif
-#ifdef USE_PF_INET6
     case AF_INET6: return !IN6_IS_ADDR_UNSPECIFIED(&lsa->pi.in6.ipi6_addr);
-#endif
     default: return 0;
   }
 #else
@@ -631,10 +619,8 @@ addr_match (const struct openvpn_sockaddr *a1, const struct openvpn_sockaddr *a2
   switch(a1->addr.sa.sa_family) {
     case AF_INET:
       return a1->addr.in4.sin_addr.s_addr == a2->addr.in4.sin_addr.s_addr;
-#ifdef USE_PF_INET6
     case AF_INET6:
       return IN6_ARE_ADDR_EQUAL(&a1->addr.in6.sin6_addr, &a2->addr.in6.sin6_addr);
-#endif
   }
   ASSERT(0);
   return false;
@@ -648,12 +634,8 @@ addr_host (const struct openvpn_sockaddr *addr)
    * possible clash: non sense for now given
    * that we do ifconfig only IPv4
    */
-#if defined(USE_PF_INET6) 
   if(addr->addr.sa.sa_family != AF_INET)
     return 0;
-#else 
-  ASSERT(addr->addr.sa.sa_family == AF_INET);
-#endif
   return ntohl (addr->addr.in4.sin_addr.s_addr);
 }
 
@@ -664,11 +646,9 @@ addr_port_match (const struct openvpn_sockaddr *a1, const struct openvpn_sockadd
     case AF_INET:
       return a1->addr.in4.sin_addr.s_addr == a2->addr.in4.sin_addr.s_addr
 	&& a1->addr.in4.sin_port == a2->addr.in4.sin_port;
-#ifdef USE_PF_INET6
     case AF_INET6:
       return IN6_ARE_ADDR_EQUAL(&a1->addr.in6.sin6_addr, &a2->addr.in6.sin6_addr) 
 	&& a1->addr.in6.sin6_port == a2->addr.in6.sin6_port;
-#endif
   }
   ASSERT(0);
   return false;
@@ -691,11 +671,9 @@ addr_zero_host(struct openvpn_sockaddr *addr)
      case AF_INET:
        addr->addr.in4.sin_addr.s_addr = 0;
        break;
-#ifdef USE_PF_INET6
      case AF_INET6: 
        memset(&addr->addr.in6.sin6_addr, 0, sizeof (struct in6_addr));
        break;
-#endif
    }
 }
 
@@ -712,11 +690,9 @@ addr_copy_host(struct openvpn_sockaddr *dst, const struct openvpn_sockaddr *src)
      case AF_INET:
        dst->addr.in4.sin_addr.s_addr = src->addr.in4.sin_addr.s_addr;
        break;
-#ifdef USE_PF_INET6
      case AF_INET6: 
        dst->addr.in6.sin6_addr = src->addr.in6.sin6_addr;
        break;
-#endif
    }
 }
 
@@ -730,15 +706,9 @@ int addr_guess_family(int proto, const char *name);
 static inline int
 af_addr_size(unsigned short af)
 {
-#if defined(USE_PF_INET6) || defined (USE_PF_UNIX)
    switch(af) {
      case AF_INET: return sizeof (struct sockaddr_in);
-#ifdef USE_PF_UNIX
-     case AF_UNIX: return sizeof (struct sockaddr_un);
-#endif
-#ifdef USE_PF_INET6
      case AF_INET6: return sizeof (struct sockaddr_in6);
-#endif
      default: 
 #if 0
       /* could be called from socket_do_accept() with empty addr */
@@ -747,9 +717,6 @@ af_addr_size(unsigned short af)
 #endif
      	return 0;
    }
-#else /* only AF_INET */
-   return sizeof(struct sockaddr_in);
-#endif
 }
 
 static inline bool
@@ -809,9 +776,7 @@ link_socket_verify_incoming_addr (struct buffer *buf,
   if (buf->len > 0)
     {
       switch (from_addr->dest.addr.sa.sa_family) {
-#ifdef USE_PF_INET6
 	case AF_INET6:
-#endif
 	case AF_INET:
 	  if (!link_socket_actual_defined (from_addr))
 	    return false;

--- a/syshead.h
+++ b/syshead.h
@@ -29,7 +29,7 @@
  * Only include if not during configure
  */
 #ifdef WIN32
-/* USE_PF_INET6: win32 ipv6 exists only after 0x0501 (XP) */
+/* PF_INET6: win32 ipv6 exists only after 0x0501 (XP) */
 #define WINVER 0x0501
 #endif
 #ifndef PACKAGE_NAME
@@ -343,7 +343,7 @@
 #ifdef WIN32
 #include <iphlpapi.h>
 #include <wininet.h>
-/* The following two headers are needed of USE_PF_INET6 */
+/* The following two headers are needed of PF_INET6 */
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #endif


### PR DESCRIPTION
- put all #ifdef'd code in place, kill the cpp symbol,
- thus in v2.3 it's not actually possible to --disable-ipv6 :)


Signed-off-by: JuanJo Ciarlante <jjo+ml@google.com>